### PR TITLE
chore(flake/nixpkgs): `698214a3` -> `5e5402ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`7a875ea1`](https://github.com/NixOS/nixpkgs/commit/7a875ea1f920e6ab5070ba0a3532a89547e991ff) | `` vimPlugins: add warning for nvimSkipModule deprecation ``                          |
| [`3e6edb83`](https://github.com/NixOS/nixpkgs/commit/3e6edb83ddcf1ef2b1af7a17bb6edd4ad1b48fb2) | `` vimPlugins: rename nvimSkipModule into nvimSkipModules ``                          |
| [`06019503`](https://github.com/NixOS/nixpkgs/commit/0601950326a4fa8d830dad43d816f32e02a5c217) | `` sblast: 0.7.0 -> 0.7.2 ``                                                          |
| [`5a4cab3f`](https://github.com/NixOS/nixpkgs/commit/5a4cab3f5f0fd9e2e7a6c417803856aeebf7a399) | `` cudaPackages.nsight-{compute,systems}: fix aarch64-linux builds ``                 |
| [`eb49eb39`](https://github.com/NixOS/nixpkgs/commit/eb49eb39cbcc54977600fa9c9a3e5f5568bd74f9) | `` luaPackages: update on 2025-03-27 ``                                               |
| [`7260fbbf`](https://github.com/NixOS/nixpkgs/commit/7260fbbfee9466d62042cd641133f583d27e752b) | `` maintainers/team-list: add adamcstephens to beam team ``                           |
| [`be101e0b`](https://github.com/NixOS/nixpkgs/commit/be101e0b10613b3d4fa3436798e99098f7b9aa4d) | `` otb: remove legacy ITK patches and outdated package definition ``                  |
| [`90861bb7`](https://github.com/NixOS/nixpkgs/commit/90861bb7cc4dc3b06a6d8d300f54becd706a3494) | `` mpls: 0.12.1 -> 0.13.2 ``                                                          |
| [`33490831`](https://github.com/NixOS/nixpkgs/commit/334908311378eb662451bfe4c9ea61b97688cda4) | `` firejail: 0.9.72 -> 0.9.74 (#393185) ``                                            |
| [`20a803e6`](https://github.com/NixOS/nixpkgs/commit/20a803e6ba18e52f8af2be2425e122ed2f4902ab) | `` openscad-unstable: add darwin specific tweaks (#387525) ``                         |
| [`9992c0fd`](https://github.com/NixOS/nixpkgs/commit/9992c0fd4d7b6e8b36c54b12867b8f5d58411696) | `` doc/option-types: fix attrTag example ``                                           |
| [`066e034b`](https://github.com/NixOS/nixpkgs/commit/066e034b83ed28dc6b7932adca31acb1670d1ee6) | `` vimPlugins.nvim-dap-vscode-js: init at 2023-03-06 ``                               |
| [`4127fc35`](https://github.com/NixOS/nixpkgs/commit/4127fc35e91d66dd2313c1064cda099c7f70e2b4) | `` git-chain: 0-unstable-2025-03-10 -> 0-unstable-2025-03-25 ``                       |
| [`0195aa79`](https://github.com/NixOS/nixpkgs/commit/0195aa79db845f22b5f98b27d3d30fdf57b6cecb) | `` vimPluginsUpdater: fix nvim-tree-sitter update ``                                  |
| [`f4158862`](https://github.com/NixOS/nixpkgs/commit/f415886205781102a38502a616aa91541d0e8f75) | `` swh: init at 4.0.0 ``                                                              |
| [`c10fe0a9`](https://github.com/NixOS/nixpkgs/commit/c10fe0a9c2c1207f6e9c1f8ca8ccbad603d4bd50) | `` python312Packages.swh-scanner: init at 0.8.3 ``                                    |
| [`7c04f0b5`](https://github.com/NixOS/nixpkgs/commit/7c04f0b5a70b1ae35c50b1fa45df5630278269b6) | `` python312Packages.swh-web-client: init at 0.9.0 ``                                 |
| [`012061fe`](https://github.com/NixOS/nixpkgs/commit/012061fe940978661af6da7e090d5f4073258c4b) | `` python312Packages.swh-auth: init at 0.10.0 ``                                      |
| [`02d6bc8d`](https://github.com/NixOS/nixpkgs/commit/02d6bc8d89f72ff32b9105e767a48775425d6c71) | `` python312Packages.swh-core: init at 4.0.0 ``                                       |
| [`b7ec5ffe`](https://github.com/NixOS/nixpkgs/commit/b7ec5ffeca7d77ebd642d2d506f9f07c6abdf237) | `` python312Packages.swh-model: init at 7.1.0 ``                                      |
| [`bdee9350`](https://github.com/NixOS/nixpkgs/commit/bdee9350f584ebe49899a4ef50fcc01a3327cf40) | `` gossip: 0.13.0 -> 0.14.0 ``                                                        |
| [`16af41c1`](https://github.com/NixOS/nixpkgs/commit/16af41c1360f2e191294d776e61d0ad2154c3012) | `` kanidm: ensure matching versions for kanidm.withSecretProvisioning ``              |
| [`1907566a`](https://github.com/NixOS/nixpkgs/commit/1907566ac616e724b204fc11472b4d36aa018f96) | `` home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: 0.9.0 -> 0.10.0 ``  |
| [`5cd80651`](https://github.com/NixOS/nixpkgs/commit/5cd806515d0cadb832ffa09728d00233a096faa7) | `` home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: Fix updateScript `` |
| [`39305682`](https://github.com/NixOS/nixpkgs/commit/393056823fb256cd49c62cf3a071c401df43e608) | `` telegram-desktop: 5.13.0 -> 5.13.1 ``                                              |
| [`37f622fb`](https://github.com/NixOS/nixpkgs/commit/37f622fbb7a94bc482666c36df44ad13e5347498) | `` telegram-desktop: 5.12.3 -> 5.13.0 ``                                              |
| [`42d70d39`](https://github.com/NixOS/nixpkgs/commit/42d70d393c4122c857a5eadad5cc773f869b4f5b) | `` krdc: temporarily disable rdp support ``                                           |
| [`c1b451ea`](https://github.com/NixOS/nixpkgs/commit/c1b451eabc00cdcb55b953b70fe1770f3deea228) | `` koboldcpp: 1.85 -> 1.86.2 ``                                                       |
| [`acdcd27d`](https://github.com/NixOS/nixpkgs/commit/acdcd27da6376f5db109612429aeba0d17757a92) | `` rocketchat-desktop: 4.1.2 -> 4.2.0 ``                                              |
| [`e5fc692e`](https://github.com/NixOS/nixpkgs/commit/e5fc692ea19ee52c6b817224f1f39506a43c6927) | `` yay: init at 12.4.2 ``                                                             |
| [`4dc6984b`](https://github.com/NixOS/nixpkgs/commit/4dc6984b698d634d878bac53ba42f408fb240bfd) | `` nuclear: 0.6.42 -> 0.6.43 ``                                                       |
| [`4d47b3a8`](https://github.com/NixOS/nixpkgs/commit/4d47b3a8561c1ec9eb7aea9110483d221afbeca1) | `` krdp: backport freerdp3 support to fix build ``                                    |
| [`75ffe9e0`](https://github.com/NixOS/nixpkgs/commit/75ffe9e0a853e027dd85d1199426b79c6726e992) | `` python312Packages.mirakuru: unbreak build by disabling one test ``                 |
| [`b5de795b`](https://github.com/NixOS/nixpkgs/commit/b5de795ba9ee2b15fee9881cc1de4ddc9131fe35) | `` python312Packages.attrs-strict: init at 1.0.1 ``                                   |
| [`ee0fc355`](https://github.com/NixOS/nixpkgs/commit/ee0fc3559eef448209dc7de4ec7344f7524bf98e) | `` libblake3: use older tbb ``                                                        |
| [`dff54528`](https://github.com/NixOS/nixpkgs/commit/dff5452805e81382647bae45c41767f1b6b7b1f9) | `` freerdp: deprecate aliases ``                                                      |
| [`c892f85e`](https://github.com/NixOS/nixpkgs/commit/c892f85e78098d835a52bb219bd22993241bc503) | `` treewide: switch to unpinned freerdp ``                                            |
| [`388815b1`](https://github.com/NixOS/nixpkgs/commit/388815b181e297e1ad42d4c302e7808460b4305e) | `` freerdp: drop freerdp 2.x, move to by-name ``                                      |
| [`240064db`](https://github.com/NixOS/nixpkgs/commit/240064db50b9ff76957db83a827620a93be6e788) | `` python312Packages.google-cloud-pubsub: 2.28.0 -> 2.29.0 ``                         |
| [`b3640db3`](https://github.com/NixOS/nixpkgs/commit/b3640db3ea4b92930d1e87fa81f338448fe2ca2d) | `` python312Packages.reflex-chakra: 0.6.3 -> 0.7.0 ``                                 |
| [`e30d3148`](https://github.com/NixOS/nixpkgs/commit/e30d3148b9f865490d4e946396663c953a2a4e4f) | `` python312Packages.pytest-postrgesql: fix on darwin sandbox ``                      |
| [`af05cb1e`](https://github.com/NixOS/nixpkgs/commit/af05cb1ed4d21ae4989f76cc3e93d3e66862c34f) | `` tacent: fix tag ``                                                                 |
| [`a46206ab`](https://github.com/NixOS/nixpkgs/commit/a46206abeffb012390bd458866c3fd8d863632b8) | `` woodpecker-plugin-git: 2.6.2 -> 2.6.3 ``                                           |
| [`8b4c587e`](https://github.com/NixOS/nixpkgs/commit/8b4c587edf8db9fc5cc2ed672630fe66e1397f83) | `` osqp-eigen: 0.9.0 -> 0.10.0 ``                                                     |
| [`37a9d3ab`](https://github.com/NixOS/nixpkgs/commit/37a9d3abde12337b1db67c713b41f85c558a1598) | `` easytier: 2.2.2 -> 2.2.4 ``                                                        |
| [`b6d12f59`](https://github.com/NixOS/nixpkgs/commit/b6d12f5938461576dcd8d0e4dfaceb89df41f86f) | `` add overrideRocqDerivation ``                                                      |
| [`ebee9a43`](https://github.com/NixOS/nixpkgs/commit/ebee9a439a50bbe2a0a61ef886b25a6c13198332) | `` db-rest: 6.0.6 -> 6.1.0 ``                                                         |
| [`b962c1fd`](https://github.com/NixOS/nixpkgs/commit/b962c1fd3668c154489a7a0a6e297d9d856ce9ac) | `` python3Packages.hickle: add numpy 2.x support ``                                   |
| [`09534278`](https://github.com/NixOS/nixpkgs/commit/09534278d8aab779c16a87a253b7d28b1467a395) | `` snapcraft: 8.7.2 -> 8.7.3 ``                                                       |
| [`53b13901`](https://github.com/NixOS/nixpkgs/commit/53b13901c3728f0c386e5a3cc916e5db3c3a4058) | `` python313Packages.binsync: 5.2.0 -> 5.3.0 ``                                       |
| [`e0e4039e`](https://github.com/NixOS/nixpkgs/commit/e0e4039e481cc625bc2ee31ac3581d7cc8255468) | `` python3Packages.binsync: init at 5.2.0 ``                                          |
| [`a328fc31`](https://github.com/NixOS/nixpkgs/commit/a328fc31ba2c3bbf777e40eba10a1d035ca2cff9) | `` golangci-lint-langserver: temporarily disable tests ``                             |
| [`bf3ba305`](https://github.com/NixOS/nixpkgs/commit/bf3ba3053be6e02fcdce1efcca4478dc9edda3ea) | `` beetsPackages.copyartifacts: refactor ``                                           |
| [`68feba21`](https://github.com/NixOS/nixpkgs/commit/68feba21e95e36628b7ba2e786c60532ce8594c9) | `` beetsPackages.copyartifacts: add changelog to meta ``                              |
| [`e64dc769`](https://github.com/NixOS/nixpkgs/commit/e64dc7696dda04845583f7fd0150be391696e99d) | `` gnomeExtensions.unite: 81 -> 82 ``                                                 |
| [`d73ff0a7`](https://github.com/NixOS/nixpkgs/commit/d73ff0a790363389175f23b3600a732ecd833bf2) | `` otb: fix python support ``                                                         |
| [`2db0e733`](https://github.com/NixOS/nixpkgs/commit/2db0e733cab034dd4926892663b50a0b36b57aac) | `` tinty: 0.26.1 -> 0.27.0 ``                                                         |
| [`3b27520c`](https://github.com/NixOS/nixpkgs/commit/3b27520c95b0d83725d4ed21f54c7bb13df4c5e8) | `` pkgsite: 0-unstable-2025-03-12 -> 0-unstable-2025-03-21 ``                         |
| [`01ce3ebd`](https://github.com/NixOS/nixpkgs/commit/01ce3ebd11aeddb6985275d1d51bf9199b4a1613) | `` polarity: latest-unstable-2025-03-14 -> latest-unstable-2025-03-26 ``              |
| [`34d86191`](https://github.com/NixOS/nixpkgs/commit/34d86191d7e712b679c9677039b205801a7fc0bf) | `` nix-eval-jobs: 2.25.0 -> 2.26.0 ``                                                 |
| [`12a701f1`](https://github.com/NixOS/nixpkgs/commit/12a701f1aeeed522141d87179b3dabdb6d431557) | `` v2ray-domain-list-community: 20250312064659 -> 20250326132209 ``                   |
| [`d30cbc22`](https://github.com/NixOS/nixpkgs/commit/d30cbc2243a51581e6089bc252c079a3970e7d7a) | `` eww: 0.6.0-unstable-2025-02-16 -> 0.6.0-unstable-2025-03-25 ``                     |
| [`c68b327a`](https://github.com/NixOS/nixpkgs/commit/c68b327aeda6d4fd2e352384fc0b22d8aa280266) | `` zulip: 5.11.1 → 5.12.0 ``                                                          |
| [`be459749`](https://github.com/NixOS/nixpkgs/commit/be459749dc4c0171b162a6efae875a87969567d8) | `` python312Packages.wolf-comm: 0.0.23 -> 0.0.47 ``                                   |
| [`2a5b34dc`](https://github.com/NixOS/nixpkgs/commit/2a5b34dc0d5981cb853b4195350dc6c051bda633) | `` dioxionary: init at 1.1.4 ``                                                       |
| [`c8560d16`](https://github.com/NixOS/nixpkgs/commit/c8560d1673ba986f5dfb89dfb168bd8713195d77) | `` maintainers: add ulic-youthlic ``                                                  |
| [`8cf61a37`](https://github.com/NixOS/nixpkgs/commit/8cf61a370677a3d46207ba36533b5d10c316d1dd) | `` pretix.plugins.stretchgoals: unstable-2023-11-27 -> 1.0.1 ``                       |
| [`00011160`](https://github.com/NixOS/nixpkgs/commit/0001116074cc3ccbc30583e945edc0196be82a4a) | `` pretix.plugins.servicefees: init at 1.13.1 ``                                      |
| [`4604e203`](https://github.com/NixOS/nixpkgs/commit/4604e203304fb398d32140820dce9532ac514692) | `` pretix.plugins.mollie: 2.3.0 -> 2.3.1 ``                                           |
| [`f8590e2e`](https://github.com/NixOS/nixpkgs/commit/f8590e2e4197f78a3e00e4d0fe007d98ffb0023a) | `` pretix: 2025.2.0 -> 2025.3.0 ``                                                    |
| [`4bf9858b`](https://github.com/NixOS/nixpkgs/commit/4bf9858b9df3df4b78f811249815a967bc431e59) | `` copilot-language-server: 1.290.0 -> 1.292.0 ``                                     |
| [`08670a00`](https://github.com/NixOS/nixpkgs/commit/08670a0032f697dc85661d29bb86a02cdeb8930b) | `` evcc: 0.201.1 -> 0.202.0 ``                                                        |
| [`2f497054`](https://github.com/NixOS/nixpkgs/commit/2f49705481b6a0eccdf269b65b57fb09815b9fa6) | `` vimPlugins.nvim-treesitter: update on 2025-03-27 ``                                |
| [`ec529ce5`](https://github.com/NixOS/nixpkgs/commit/ec529ce5152e039f79bf5f56868b09cd446984dd) | `` vimPlugins: update on 2025-03-27 ``                                                |
| [`0162ad24`](https://github.com/NixOS/nixpkgs/commit/0162ad243dfdad053872ac36951cdbf4e010841a) | `` remarshal_0_17,python3Packages.remarshal: add mainProgram (#390902) ``             |
| [`c62819e5`](https://github.com/NixOS/nixpkgs/commit/c62819e5e581d95fffd56a39b2305571c355f19b) | `` vimPlugins.nvim-dap-view: init at 2025-01-19 ``                                    |
| [`ec5733ec`](https://github.com/NixOS/nixpkgs/commit/ec5733ecb9dade28f2121898182896448d4d1a0f) | `` rabbitmqadmin-ng: 0.27.0 -> 0.29.0 ``                                              |
| [`0b00016a`](https://github.com/NixOS/nixpkgs/commit/0b00016a2059a15e821a9bd28895ea1e77998bec) | `` pulsar: 1.126.0 -> 1.127.0 ``                                                      |
| [`a29b770c`](https://github.com/NixOS/nixpkgs/commit/a29b770cd77437a18a0d52b125bdc72bc3043465) | `` brush: 0.2.15 -> 0.2.16 ``                                                         |
| [`29ed2818`](https://github.com/NixOS/nixpkgs/commit/29ed28180ba0119ce7a103a6aa87ceea57daa51f) | `` svu: 3.2.2 -> 3.2.3 ``                                                             |
| [`2c77de44`](https://github.com/NixOS/nixpkgs/commit/2c77de4416f98f190dc04f92ed34df88f8d5bbf6) | `` pomerium-cli: 0.23.0 -> 0.29.0 ``                                                  |
| [`d665abca`](https://github.com/NixOS/nixpkgs/commit/d665abcac64eec52b423561be846efb242ae88fa) | `` SDL_ttf: unmark insecure ``                                                        |
| [`3818e537`](https://github.com/NixOS/nixpkgs/commit/3818e5372e6fdc88c23302cd11f35c0fdd1cabd6) | `` SDL_mixer: add a passthru.test and some words of caution ``                        |
| [`91d12168`](https://github.com/NixOS/nixpkgs/commit/91d1216801c25452878b67827189dec1b160a615) | `` SDL_ttf: 2.0.11 -> 2.0.11.1-unstable-2024-04-23 ``                                 |
| [`c4fdb21e`](https://github.com/NixOS/nixpkgs/commit/c4fdb21efd847fb4b2e13938329d274d7c12aab4) | `` SDL_net: 1.2.8 -> 1.2.8-unstable-2024-04-23 ``                                     |
| [`2e4f8175`](https://github.com/NixOS/nixpkgs/commit/2e4f81754e928ed25032677900f415b93b65045e) | `` SDL_image: 1.2.12 -> 1.2.12-unstable-2025-02-13 ``                                 |
| [`491d1a58`](https://github.com/NixOS/nixpkgs/commit/491d1a58ad0d5dd7b8e9d807d7e98e4ee4d30040) | `` SDL1: drop ``                                                                      |
| [`bb2e93f0`](https://github.com/NixOS/nixpkgs/commit/bb2e93f0e60c9b824c46d40220d3570d913c896e) | `` nuclei: 3.3.10 -> 3.4.0 ``                                                         |
| [`e529c511`](https://github.com/NixOS/nixpkgs/commit/e529c511ba18a9ed75ed3a1d7d7bf759f95a144a) | `` python312Packages.sentence-transformers: 3.4.1 -> 4.0.1 ``                         |
| [`5087f572`](https://github.com/NixOS/nixpkgs/commit/5087f5729678f11e6bf2c10d2a0a38ef5811f946) | `` ff2mpv-rust: 1.1.5 -> 1.1.6 ``                                                     |
| [`a0711ea8`](https://github.com/NixOS/nixpkgs/commit/a0711ea841c1a2ba4d9fc50d1efb3cf4010a5189) | `` zabbix-agent2-plugin-postgresql: 7.2.3 -> 7.2.4 ``                                 |
| [`2f11d937`](https://github.com/NixOS/nixpkgs/commit/2f11d9378aa946e5e434a1fdebc1325fe8fec666) | `` factorio-demo: 2.0.27 -> 2.0.42 ``                                                 |
| [`c8f31c22`](https://github.com/NixOS/nixpkgs/commit/c8f31c22ebf0388d50ba20c22187201160849ae8) | `` crystal-dock: 2.10 -> 2.11 ``                                                      |
| [`8af4a78d`](https://github.com/NixOS/nixpkgs/commit/8af4a78d0d0486de96e0207eba72ff43382eb2dd) | `` nodePackages.@prisma/language-server: drop ``                                      |
| [`492f746e`](https://github.com/NixOS/nixpkgs/commit/492f746e4096b6e19beb67b3c8630bbdfbf63a33) | `` cura-appimage: 5.9.1 -> 5.10.0 ``                                                  |