### PR TITLE
chore(flake/nixpkgs): `f675531b` -> `2631b0b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744232761,
-        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`6fdfd229`](https://github.com/NixOS/nixpkgs/commit/6fdfd229448be2ffc1b23f8319f81ebffa6d0522) | `` ephemeral: drop due to upstream archival ``                                                    |
| [`f516607c`](https://github.com/NixOS/nixpkgs/commit/f516607cdc82d0d9b7961f85df0a7ce3e73329f5) | `` trilium-next-desktop: 0.92.6 -> 0.92.7 ``                                                      |
| [`6572a9c9`](https://github.com/NixOS/nixpkgs/commit/6572a9c92693d5d795970d1995cd907e97e9b8bc) | `` php83: 8.3.19 -> 8.3.20 ``                                                                     |
| [`6b9ee438`](https://github.com/NixOS/nixpkgs/commit/6b9ee4386f01e7ced3f87db38f2e39bbf1851127) | `` php8{1-4}Extensions.parallel: 1.2.4 -> 1.2.6 ``                                                |
| [`afd5a4bf`](https://github.com/NixOS/nixpkgs/commit/afd5a4bf7ba952d99ed40f894d848b45a0135fd0) | `` firewalld: remove linux-only dependencies ``                                                   |
| [`ea168da7`](https://github.com/NixOS/nixpkgs/commit/ea168da721a097d9364b113b8352f0546fe50dff) | `` firewalld: add NIX_FIREWALLD_CONFIG_PATH ``                                                    |
| [`2b32dee3`](https://github.com/NixOS/nixpkgs/commit/2b32dee3c3fc668cfa8015151cf62532dfc8669b) | `` firewalld: remove testsuite ``                                                                 |
| [`367f4890`](https://github.com/NixOS/nixpkgs/commit/367f4890275bde16bbd2a5f60e9bc111e09ff7fc) | `` firewalld: fix i18n ``                                                                         |
| [`ee19ecd4`](https://github.com/NixOS/nixpkgs/commit/ee19ecd464c92be604bc98433b985b5dc233637f) | `` firewalld: wrap gui programs with qt6 ``                                                       |
| [`3a1c054b`](https://github.com/NixOS/nixpkgs/commit/3a1c054bb9390e158652c1efe20367b2eb8ee252) | `` firewalld: fix paths ``                                                                        |
| [`27d754aa`](https://github.com/NixOS/nixpkgs/commit/27d754aac6dff811c2a01562a65a5380250ef40f) | `` firewalld: fix networkmanager integration ``                                                   |
| [`099202f1`](https://github.com/NixOS/nixpkgs/commit/099202f1baba54c072e3f10d5a28da79a010064a) | `` firewalld: use pyqt6 instead of pyqt5 ``                                                       |
| [`652cac38`](https://github.com/NixOS/nixpkgs/commit/652cac382a47bc721e84552a2ef7d24e1df74721) | `` firewalld: wrap non-gui programs with gtk ``                                                   |
| [`dacd3b40`](https://github.com/NixOS/nixpkgs/commit/dacd3b409bd0f74f67c8c407b5d7b2ad955b4a32) | `` firewalld: install applet and config for gui ``                                                |
| [`ea576076`](https://github.com/NixOS/nixpkgs/commit/ea57607629880fda5c879797aa8e86846392a2a0) | `` firewalld: add runtime programs as build inputs ``                                             |
| [`448091b0`](https://github.com/NixOS/nixpkgs/commit/448091b05cacb5a1e85bff718568d4da58d75e7a) | `` firewalld: avoid autoreconfHook ``                                                             |
| [`f301f1ca`](https://github.com/NixOS/nixpkgs/commit/f301f1ca2bb3fcc70d7c0c7e2a0c002208a4833d) | `` firewalld: update meta attributes ``                                                           |
| [`af86ed6d`](https://github.com/NixOS/nixpkgs/commit/af86ed6d4fbc7bf80af8d0227ed19c50db2e1a60) | `` tailwindcss_4: update script add missing ripgrep ``                                            |
| [`8e65f3d2`](https://github.com/NixOS/nixpkgs/commit/8e65f3d23dd1a484f5c765a0c6d9999c04e5fb63) | `` tailwindcss_4: 4.1.2 -> 4.1.3 ``                                                               |
| [`3df73bdf`](https://github.com/NixOS/nixpkgs/commit/3df73bdfb15dfa4a05db9d6ef3336138b1d28c76) | `` vectorcode: 0.5.3 -> 0.5.5 ``                                                                  |
| [`60dac5e1`](https://github.com/NixOS/nixpkgs/commit/60dac5e176b0fc6318169be9613504d2f9a96253) | `` yaziPlugins.yatline: 0-unstable-2025-03-05 -> 0-unstable-2025-04-11 ``                         |
| [`a1726999`](https://github.com/NixOS/nixpkgs/commit/a1726999659146a4d5018e22d212829c1b4bb6dc) | `` maintainers: add tanya1866 ``                                                                  |
| [`92fdead6`](https://github.com/NixOS/nixpkgs/commit/92fdead6969455311a4cd17d1f3a8abca4515bd2) | `` svt-av1-psy: build against hdr10plus ``                                                        |
| [`16287b23`](https://github.com/NixOS/nixpkgs/commit/16287b231e64439a12a36d2f08e4d3af30a18bb6) | `` hdr10plus_tool: update hdr10tool library on update ``                                          |
| [`9558cbd8`](https://github.com/NixOS/nixpkgs/commit/9558cbd8f9d829ce6b905ad007f430759177cecf) | `` hdr10plus: init at version 2.1.3 ``                                                            |
| [`bfce7b7e`](https://github.com/NixOS/nixpkgs/commit/bfce7b7e39808d976afe23c65e52422973aec5a6) | `` podman-desktop: 1.17.1 -> 1.17.2 (#397403) ``                                                  |
| [`78f3901a`](https://github.com/NixOS/nixpkgs/commit/78f3901ab1fdb4cf5495b34d68000c51f6babcb4) | `` hyprland-protocols: 0.6.3 -> 0.6.4 (#398052) ``                                                |
| [`d56986f8`](https://github.com/NixOS/nixpkgs/commit/d56986f88c65c292ad1771293309ec09e9314e25) | `` python312Packages.marko: 2.1.2 -> 2.1.3 ``                                                     |
| [`eacbeb75`](https://github.com/NixOS/nixpkgs/commit/eacbeb75c30066b5f56ec44b8314160ed1947655) | `` qtcreator: 16.0.0 -> 16.0.1 ``                                                                 |
| [`700e5d89`](https://github.com/NixOS/nixpkgs/commit/700e5d898db1a75a18fe95244dfd8194549f34f3) | `` dotnetCorePackages.sdk_10_0-bin: 10.0.100-preview.2.25164.34 -> 10.0.100-preview.3.25201.16 `` |
| [`11dac076`](https://github.com/NixOS/nixpkgs/commit/11dac07613a1908c63a3271774d789be26138587) | `` dotnetCorePackages.dotnet_10.vmr: 10.0.0-preview.2 -> 10.0.0-preview.3 ``                      |
| [`f14a52c8`](https://github.com/NixOS/nixpkgs/commit/f14a52c81dd682cc6a9f25d6ed91ed654813ccf4) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.3 -> 9.0.4 ``                                             |
| [`df2521f4`](https://github.com/NixOS/nixpkgs/commit/df2521f4790b17395169d98a49269ba9fdac8bed) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.14 -> 8.0.15 ``                                           |
| [`9ccf77ef`](https://github.com/NixOS/nixpkgs/commit/9ccf77ef211cfc925aa4d1df55260922d2642d31) | `` dotnetCorePackages.sdk_8_0-bin: 8.0.407 -> 8.0.408 ``                                          |
| [`c1504f7f`](https://github.com/NixOS/nixpkgs/commit/c1504f7f73ad0db161b068ad9166bdd286c30bf3) | `` dotnetCorePackages.sdk_9_0-bin: 9.0.202 -> 9.0.203 ``                                          |
| [`a38bbfce`](https://github.com/NixOS/nixpkgs/commit/a38bbfceaddee946b043d6e1cbc899aabe6a5772) | `` dotnetCorePackages.dotnet_{8,9,10}.aspnetcore: copy App package only ``                        |
| [`be9c47e3`](https://github.com/NixOS/nixpkgs/commit/be9c47e30185b5c9c9ba40f873c6c23b34f7ba31) | `` dotent/update.sh: ignore new apphost-pack and targeting-pack releases ``                       |
| [`cbdad870`](https://github.com/NixOS/nixpkgs/commit/cbdad8704f12f459636f11a65aef880a9cb82563) | `` dotnet/update.sh: set inherit_errexit ``                                                       |
| [`569b88b2`](https://github.com/NixOS/nixpkgs/commit/569b88b27143ee162cb53cb4a2dd1091915bcc63) | `` audiothekar: disable parallel building ``                                                      |
| [`60e56030`](https://github.com/NixOS/nixpkgs/commit/60e56030b92007fa0aef649ba497aead04346fba) | `` yaziPlugins.lazygit: init at 0-unstable-2025-03-31 ``                                          |
| [`23f650bd`](https://github.com/NixOS/nixpkgs/commit/23f650bd3656da13a90f94616d8b87616492a728) | `` yaziPlugins.projects: init at 0-unstable-2025-03-02 ``                                         |
| [`21fe06f8`](https://github.com/NixOS/nixpkgs/commit/21fe06f8a80d86c948b8cb1005413d6c1138a83e) | `` yaziPlugins.time-travel: init at 0-unstable-2025-03-02 ``                                      |
| [`65f7d2e4`](https://github.com/NixOS/nixpkgs/commit/65f7d2e429a08400abebec3b00d2bfb6f4da4475) | `` yaziPlugins.rich-preview: init at 0-unstable-2025-01-18 ``                                     |
| [`eaaa73e1`](https://github.com/NixOS/nixpkgs/commit/eaaa73e119a76b00155b473f5dcf9d27008999fb) | `` yaziPlugins.yatline: init at 0-unstable-2025-03-05 ``                                          |
| [`c315b3bf`](https://github.com/NixOS/nixpkgs/commit/c315b3bf576f1e623e90742180582424d947c4e4) | `` yaziPlugins.duckdb: init at 25.4.8-unstable-2025-04-08 ``                                      |
| [`ec023f3c`](https://github.com/NixOS/nixpkgs/commit/ec023f3c8ee7d9006de18ca09d4705133dff1011) | `` yaziPlugins.bypass: 0-unstable-2025-02-16 -> 0-unstable-2025-04-09 ``                          |
| [`369560e5`](https://github.com/NixOS/nixpkgs/commit/369560e5b63278e671694c12fa7de628fcf12701) | `` postgresqlPackages.pg-gvm: 22.6.8 -> 22.6.9 ``                                                 |
| [`40d4b689`](https://github.com/NixOS/nixpkgs/commit/40d4b689f3f7fd1570fb726f43b7d1899e80ecab) | `` python312Packages.transformers: 4.51.1 -> 4.51.2 ``                                            |
| [`d5ae9359`](https://github.com/NixOS/nixpkgs/commit/d5ae9359532f65c846f1ae0ef04a5b120bba66a7) | `` cargo-codspeed: 2.10.0 -> 2.10.1 ``                                                            |
| [`e19eadc3`](https://github.com/NixOS/nixpkgs/commit/e19eadc3a57e4d314b9447e5ba6dc189121fbc5b) | `` inputplumber: 0.50.0 -> 0.52.1 ``                                                              |
| [`d2fb99b6`](https://github.com/NixOS/nixpkgs/commit/d2fb99b640cdf37735f03958ad29001bf69963e6) | `` nixos/conduwuit: remove ``                                                                     |
| [`35de3d67`](https://github.com/NixOS/nixpkgs/commit/35de3d6754924b8d4e33f57d2e61d9ffb7144806) | `` conduwuit: mark as EOL ``                                                                      |
| [`aa5bb3a6`](https://github.com/NixOS/nixpkgs/commit/aa5bb3a694fb1876a0f81de4d124e410ffcc3435) | `` bpftrace: 0.23.0 -> 0.23.1 ``                                                                  |
| [`108b2148`](https://github.com/NixOS/nixpkgs/commit/108b214848b666f3d4cb1c7e46848ef297be184c) | `` cargo-mobile2: 0.17.5 -> 0.17.6 ``                                                             |
| [`03afb006`](https://github.com/NixOS/nixpkgs/commit/03afb0066f2fd6c9ab807a818967d853295e5bf8) | `` signal-desktop-source: 7.49.0 -> 7.50.0 ``                                                     |
| [`e1e6d98d`](https://github.com/NixOS/nixpkgs/commit/e1e6d98ddb6d09aebb94f9d7ae7d5550703563b2) | `` wasabiwallet: 2.0.8.1 -> 2.5.1 ``                                                              |
| [`ee70ef78`](https://github.com/NixOS/nixpkgs/commit/ee70ef78568f4583ac583fae7596bad9a2c44cb5) | `` suitesparse-graphblas: 10.0.2 -> 10.0.3 ``                                                     |
| [`3d87aa42`](https://github.com/NixOS/nixpkgs/commit/3d87aa42a644fc387562491a3a4b398bbf691d8d) | `` twitch-hls-client: 1.3.13 -> 1.3.14 ``                                                         |
| [`6a2be790`](https://github.com/NixOS/nixpkgs/commit/6a2be790086d77cececa140f224bde065b3cdda9) | `` php84Extensions.phalcon: remove broken flag ``                                                 |
| [`085d167d`](https://github.com/NixOS/nixpkgs/commit/085d167d8b0e2c9f713f362485f655474529a27d) | `` xl2tpd: 1.3.18 -> 1.3.19 ``                                                                    |
| [`f790b874`](https://github.com/NixOS/nixpkgs/commit/f790b874ae61325b2f43d2170b1750398e3fcf82) | `` affine: 0.20.5 -> 0.21.2, fix darwin build ``                                                  |
| [`99c18ee6`](https://github.com/NixOS/nixpkgs/commit/99c18ee6eab53fa8bcacb3fe5bd9df6bdeb28f1f) | `` amazon-q-cli: 1.7.2 -> 1.7.3 ``                                                                |
| [`43282ed6`](https://github.com/NixOS/nixpkgs/commit/43282ed6ec565e8ae16456161f7f69b7f78d0103) | `` php: 8.4.5 -> 8.4.6 ``                                                                         |
| [`c6ac9fba`](https://github.com/NixOS/nixpkgs/commit/c6ac9fba440e5f50c91104f2bfe3e9a36caf7ca0) | `` hydralauncher: 3.3.1 -> 3.4.0 ``                                                               |
| [`dbd8a4c9`](https://github.com/NixOS/nixpkgs/commit/dbd8a4c9fc9db6b33eec1cd89098d7d7bd22234d) | `` direnv: 2.35.0 -> 2.36.0 (#397950) ``                                                          |
| [`85a3655b`](https://github.com/NixOS/nixpkgs/commit/85a3655ba712fac21bed51fe7b0347545df3cb2a) | `` espup: cleanup ``                                                                              |
| [`355beb7c`](https://github.com/NixOS/nixpkgs/commit/355beb7ceb7ad70589771616828b86c7016e5f62) | `` cloud-provider-kind: init at 0.6.0 (#397940) ``                                                |
| [`9a85c16b`](https://github.com/NixOS/nixpkgs/commit/9a85c16bff0c4f2a7d4914e325c6e03d8bedbc43) | `` wakapi: 2.13.2 -> 2.13.3 ``                                                                    |
| [`d0d01d8c`](https://github.com/NixOS/nixpkgs/commit/d0d01d8c0d8916bfb824b06dae414a6df67447c0) | `` luaPackages: update on 2025-04-11 ``                                                           |
| [`9bb3914b`](https://github.com/NixOS/nixpkgs/commit/9bb3914b7c1dafe2d6484f13c742f2f7cffa8d09) | `` python312Packages.mizani: 0.13.2 -> 0.13.3 ``                                                  |
| [`446b74a5`](https://github.com/NixOS/nixpkgs/commit/446b74a552a9973ad3edec8e3bd177270befc5b5) | `` {nixos/cosmic, cosmic-packages}: adopt by NixOS/cosmic team ``                                 |
| [`b13e39a7`](https://github.com/NixOS/nixpkgs/commit/b13e39a7c1efbcf0c4a0b24740787ed4b4fc7e64) | `` fn-cli: 0.6.40 -> 0.6.41 ``                                                                    |
| [`0c540cba`](https://github.com/NixOS/nixpkgs/commit/0c540cba1c2767d2a65029aafcc1b65a89959b30) | `` authentik: Add missing dependency on bash ``                                                   |
| [`21fbe41c`](https://github.com/NixOS/nixpkgs/commit/21fbe41c6ac86dff7c7ccf35bb289aaa2fd84b37) | `` signal-desktop-source: build signal-sqlcipher from source ``                                   |
| [`57b9c39a`](https://github.com/NixOS/nixpkgs/commit/57b9c39ac8d7abbe34ca2edb38b08bf363ded6ca) | `` namespace-cli: 0.0.407 -> 0.0.408 ``                                                           |
| [`79f58ff6`](https://github.com/NixOS/nixpkgs/commit/79f58ff6a21a881bf5474c10b205e596a8d9d6a1) | `` postgresqlPackages.timescaledb-apache: 2.19.1 -> 2.19.2 ``                                     |
| [`c430ec37`](https://github.com/NixOS/nixpkgs/commit/c430ec374963763af7bd04433be22042ee032aae) | `` openrazer-daemon: 3.9.0 -> 3.10.1 ``                                                           |
| [`d1769e35`](https://github.com/NixOS/nixpkgs/commit/d1769e35421bfa1fc66c057b7b2a727317eb177e) | `` luarocks-packages-updater: nixfmt-rfc-style output formatting ``                               |
| [`56b4d2a4`](https://github.com/NixOS/nixpkgs/commit/56b4d2a48d9b5e4c2541c0e0aa3dfa78873bc40b) | `` coroot-node-agent: 1.23.15 -> 1.23.16 ``                                                       |
| [`bdcc6826`](https://github.com/NixOS/nixpkgs/commit/bdcc68262e766163d0fa84c8f0fe6d61bbff98d5) | `` zint: fetch submitted patch ``                                                                 |
| [`fd806430`](https://github.com/NixOS/nixpkgs/commit/fd806430ebd78a5b162cd47018dca92466ed4237) | `` conduit: 0.9.3 -> 0.9.4 ``                                                                     |
| [`afd8fe73`](https://github.com/NixOS/nixpkgs/commit/afd8fe7372a54c86772777540f59c1ecd883dff9) | `` saucectl: 0.194.1 -> 0.194.2 ``                                                                |
| [`468f5af1`](https://github.com/NixOS/nixpkgs/commit/468f5af1269171ad6a7b4b636066c9b3e42bc310) | `` pulumi: skip flaky test ``                                                                     |
| [`90cf9a29`](https://github.com/NixOS/nixpkgs/commit/90cf9a29acf1292c4f831df5e74efd4fdd0f2c9b) | `` twitch-cli: 1.1.24 -> 1.1.25 ``                                                                |
| [`c2fad35d`](https://github.com/NixOS/nixpkgs/commit/c2fad35d4c87a8bf29fc1f4e0c0869878cb164ba) | `` pulumi: fix check phase ``                                                                     |
| [`78f7900d`](https://github.com/NixOS/nixpkgs/commit/78f7900d2155efc9960cf8be40b77243609837a2) | `` pulumi: 3.156.0 -> 3.162.0 ``                                                                  |
| [`cc4b71fb`](https://github.com/NixOS/nixpkgs/commit/cc4b71fb86d0ce53a824c2d9dfeab2faa383ee76) | `` pulumi: add pulumiPackages.pulumi-{go,nodejs,python} to passthru.tests ``                      |
| [`a0763eb3`](https://github.com/NixOS/nixpkgs/commit/a0763eb34360490ec7933c2d08046fe273f48616) | `` pulumi: add python3Packages.pulumi to passthru.tests ``                                        |
| [`f19e622f`](https://github.com/NixOS/nixpkgs/commit/f19e622fcb1281fddc8a34e49821142b1b277e01) | `` python3Packages.pulumi: do not write junit report ``                                           |
| [`930daefc`](https://github.com/NixOS/nixpkgs/commit/930daefcf00dca23ef7971b0ad9ee304391dc96b) | `` pulumi: add update script ``                                                                   |
| [`568d2e6a`](https://github.com/NixOS/nixpkgs/commit/568d2e6ab809d14b1c23af26061fea2ea9bb31af) | `` garnet: use target packages from sdk ``                                                        |
| [`0d46095c`](https://github.com/NixOS/nixpkgs/commit/0d46095c4cc99169673af54b34c7b199b05607a0) | `` picolibc: 1.8.9 -> 1.8.9-2 ``                                                                  |
| [`42508645`](https://github.com/NixOS/nixpkgs/commit/4250864535296148bc93c8637761ac7721014119) | `` kemai: 0.10.0 -> 0.11.1 ``                                                                     |
| [`3adc1621`](https://github.com/NixOS/nixpkgs/commit/3adc16211c77a4a53d65ef1170dcfeda6e0c408a) | `` magic-enum: 0.9.6 -> 0.9.7 ``                                                                  |
| [`287bb37a`](https://github.com/NixOS/nixpkgs/commit/287bb37acdc091eaf4bd73b763ba41d2e2aa23c7) | `` cirrus-cli: 0.140.8 -> 0.141.0 ``                                                              |
| [`6ef009eb`](https://github.com/NixOS/nixpkgs/commit/6ef009eb68b7a9401037fc059c206173eb063385) | `` q2pro: 0-unstable-2025-03-26 -> 0-unstable-2025-04-03 ``                                       |
| [`08fa2df8`](https://github.com/NixOS/nixpkgs/commit/08fa2df89011db0917d73348401565ad512ddb62) | `` nezha-theme-nazhua: 0.6.3 -> 0.6.4 ``                                                          |
| [`978d35f3`](https://github.com/NixOS/nixpkgs/commit/978d35f30069b26b82389a3a565506dae9ce9240) | `` u-root: use finalAttrs ``                                                                      |
| [`270d4402`](https://github.com/NixOS/nixpkgs/commit/270d44021715335a0d88ab2f4d1fceade5164c77) | `` athens: use finalAttrs ``                                                                      |
| [`1a31e44d`](https://github.com/NixOS/nixpkgs/commit/1a31e44df9431d5852e8753ac61fef3a9abd5319) | `` distribution: use finalAttrs ``                                                                |
| [`b84bfe69`](https://github.com/NixOS/nixpkgs/commit/b84bfe699a264ed543a1d8ce44466930b57d96a3) | `` bluetuith: use finalAttrs ``                                                                   |
| [`7f20d5e2`](https://github.com/NixOS/nixpkgs/commit/7f20d5e29a88d24d89bb532b95e75dab47ebd640) | `` go-critic: use finalAttrs ``                                                                   |
| [`f9cfdf4f`](https://github.com/NixOS/nixpkgs/commit/f9cfdf4f800aabef1185097a0152a0420ec24847) | `` btcpayserver: 2.0.8 -> 2.1.0 ``                                                                |
| [`5d1cffe6`](https://github.com/NixOS/nixpkgs/commit/5d1cffe6a46a8400f46eccd2814a3290dc87af71) | `` nbxplorer: 2.5.23 -> 2.5.25 ``                                                                 |
| [`51af7d60`](https://github.com/NixOS/nixpkgs/commit/51af7d609d523cd13fac12fb80a528e2fda5f10b) | `` jj: use finalAttrs ``                                                                          |
| [`99a22763`](https://github.com/NixOS/nixpkgs/commit/99a227638d1116b574b9370e3de60fddc71f1964) | `` uplosi: use finalAttrs ``                                                                      |
| [`3f8cd7a2`](https://github.com/NixOS/nixpkgs/commit/3f8cd7a2e89a8e46a3528267488a905a57797f7e) | `` emulationstation-de: 3.1.1 -> 3.2.0 ``                                                         |
| [`b14fa657`](https://github.com/NixOS/nixpkgs/commit/b14fa65751112b7514542f5dc9e58bb4b22078cd) | `` grmon: use finalAttrs ``                                                                       |
| [`34274ebb`](https://github.com/NixOS/nixpkgs/commit/34274ebbd8713eadd3c929855620d997d3afee4d) | `` capslock: use finalAttrs ``                                                                    |
| [`cfe0dd5b`](https://github.com/NixOS/nixpkgs/commit/cfe0dd5b45e77895707c9ef643bbcd729c51f566) | `` keep-sorted: use finalAttrs ``                                                                 |
| [`8c56b387`](https://github.com/NixOS/nixpkgs/commit/8c56b387c836352db00c1505928cb61c0ab11379) | `` nbxplorer/util/update-common.sh: update nix-shell deps ``                                      |
| [`2d23979e`](https://github.com/NixOS/nixpkgs/commit/2d23979ef55e96bbdbb926752c16e36105bc4e31) | `` gobusybox: use finalAttrs ``                                                                   |
| [`a890891a`](https://github.com/NixOS/nixpkgs/commit/a890891acc042fe55ddc9b31943004b133557542) | `` nixos/godns: init module ``                                                                    |
| [`015448ec`](https://github.com/NixOS/nixpkgs/commit/015448ec7b86cb2dabf82e5b7476994997c62296) | `` maintainers: add michaelvanstraten ``                                                          |
| [`ef134dcd`](https://github.com/NixOS/nixpkgs/commit/ef134dcd42d3940bc3fa0b0a6ba108d5dfa6c789) | `` python312Packages.plugp100: 5.1.3 -> 5.1.4 ``                                                  |
| [`6ec1bf6d`](https://github.com/NixOS/nixpkgs/commit/6ec1bf6d88d0e693edd20ceb201558e4021fa04b) | `` python3Packages.python-mapnik: disable failing test ``                                         |
| [`24635f89`](https://github.com/NixOS/nixpkgs/commit/24635f891b4be79829d682182a075d48c2607425) | `` ruff: 0.11.4 -> 0.11.5 ``                                                                      |
| [`24c9885c`](https://github.com/NixOS/nixpkgs/commit/24c9885c8faa2402e6d5a93932bbbdb0c9a31e24) | `` cosmic-workspaces-epoch: substitute fallback background path ``                                |
| [`c71ad753`](https://github.com/NixOS/nixpkgs/commit/c71ad753ca51734c8e583835958fa5176041449f) | `` python312Packages.hf-xet: init at 1.0.3 ``                                                     |
| [`92ec3c02`](https://github.com/NixOS/nixpkgs/commit/92ec3c02f54a73e9d03ffd8c939aa765809bc173) | `` fabric-ai: 1.4.122 -> 1.4.167 ``                                                               |
| [`97658492`](https://github.com/NixOS/nixpkgs/commit/976584924bd970226a92204da27cf91fee1369ca) | `` xcp: 0.24.0 -> 0.24.1 ``                                                                       |
| [`1a976d64`](https://github.com/NixOS/nixpkgs/commit/1a976d64bce2d5d7c722b87005d76aabd47dfcb9) | `` thepeg: mark as broken on darwin ``                                                            |