### PR TITLE
chore(flake/nixpkgs): `e06158e5` -> `292fa7d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`ea082d79`](https://github.com/NixOS/nixpkgs/commit/ea082d793dbc58dcce46f7f1b8c8cfbaf4805987) | `` cargo-shear: 1.2.6 -> 1.2.7 ``                                            |
| [`6906aed5`](https://github.com/NixOS/nixpkgs/commit/6906aed53df91c0520b9e1ce51a965dd6556e4d7) | `` pantheon.elementary-gtk-theme: 8.2.0 -> 8.2.1 ``                          |
| [`353c718f`](https://github.com/NixOS/nixpkgs/commit/353c718f020497a3c263213554ad52b6862fa5ba) | `` epiphany: Fix startup crash on Pantheon ``                                |
| [`1595eaaf`](https://github.com/NixOS/nixpkgs/commit/1595eaaf6e06c4f1db2059f55e4aecd065d2cce6) | `` markdownlint-cli: 0.44.0 -> 0.45.0 ``                                     |
| [`f3d97d08`](https://github.com/NixOS/nixpkgs/commit/f3d97d08233f0db47e56a078f13ed1eaebcb0b7a) | `` fvwm2: fix build with GCC 14 ``                                           |
| [`f5100dd9`](https://github.com/NixOS/nixpkgs/commit/f5100dd91f3ff772e5bd0f9635c695a1ff189704) | `` vimPlugins: update on 2025-05-17 ``                                       |
| [`94999c30`](https://github.com/NixOS/nixpkgs/commit/94999c30ed18501025e5a038456978e42c805105) | `` pmbootstrap: 3.3.2 -> 3.4.0 ``                                            |
| [`b59367eb`](https://github.com/NixOS/nixpkgs/commit/b59367ebe03aac27e2a83f06628bde9ab093c30e) | `` msbuild-structured-log-viewer: 2.2.476 -> 2.2.490 ``                      |
| [`e731a4f9`](https://github.com/NixOS/nixpkgs/commit/e731a4f9f0f92c7c4c633dcd698196368f0bfb37) | `` vimPlugins: resolve github repository redirects ``                        |
| [`5da49b88`](https://github.com/NixOS/nixpkgs/commit/5da49b8852e84055d7c21248a9bf82a4320418e3) | `` python313Packages.channels: 4.2.0 -> 4.2.2 ``                             |
| [`c8f871d2`](https://github.com/NixOS/nixpkgs/commit/c8f871d2ba0f9645f303e6ecba0aeb43e61e8330) | `` python313Packages.types-lxml: adjust inputs ``                            |
| [`55245e62`](https://github.com/NixOS/nixpkgs/commit/55245e62aa0d8fb002b8d88bb601f79c946a083e) | `` invidious: 2.20250504.0 -> 2.20250517.0 ``                                |
| [`b5b0cecf`](https://github.com/NixOS/nixpkgs/commit/b5b0cecfd2bc72fd66c18dcf35ae76a84a007b8a) | `` python312Packages.roadlib: add missing inputs ``                          |
| [`149ccf03`](https://github.com/NixOS/nixpkgs/commit/149ccf03d3ced9fda8f27ca7de1844effbf5b115) | `` turso-cli: 1.0.9 -> 1.0.10 ``                                             |
| [`e537cd35`](https://github.com/NixOS/nixpkgs/commit/e537cd355b478dc38f02211b4124ff95c08dee96) | `` steampipePackages.steampipe-plugin-aws: 1.12.0 -> 1.13.0 ``               |
| [`9e551493`](https://github.com/NixOS/nixpkgs/commit/9e551493273fb8870823db5804894b92712dd6f4) | `` python3Packages.oelint-data: 1.0.11 -> 1.0.14 ``                          |
| [`97a3fc54`](https://github.com/NixOS/nixpkgs/commit/97a3fc5489495cce59449dca2e16e057c0fdc434) | `` python313Packages.boto3-stubs: 1.38.16 -> 1.38.18 ``                      |
| [`4d01a324`](https://github.com/NixOS/nixpkgs/commit/4d01a324ba8836a360630603908fc57b6818e3ab) | `` python313Packages.botocore-stubs: 1.38.16 -> 1.38.18 ``                   |
| [`a3fde8ff`](https://github.com/NixOS/nixpkgs/commit/a3fde8ff473dcfbbc08bc996c682b029629c241a) | `` python312Packages.mypy-boto3-workspaces: 1.38.13 -> 1.38.17 ``            |
| [`9686ea09`](https://github.com/NixOS/nixpkgs/commit/9686ea09a1b814bc54b19ed32bab22eb647c5175) | `` python312Packages.mypy-boto3-service-quotas: 1.38.0 -> 1.38.18 ``         |
| [`49d3e4a0`](https://github.com/NixOS/nixpkgs/commit/49d3e4a089be5209743a6aa436d5a8382d1f5fbf) | `` python312Packages.mypy-boto3-neptune: 1.38.0 -> 1.38.18 ``                |
| [`1cffeb76`](https://github.com/NixOS/nixpkgs/commit/1cffeb768e1881c081446e62abc2c3c91890e31c) | `` python312Packages.mypy-boto3-glue: 1.38.12 -> 1.38.18 ``                  |
| [`58617457`](https://github.com/NixOS/nixpkgs/commit/58617457cc99598c2a7b94a31dab75582ad365c8) | `` python312Packages.mypy-boto3-emr: 1.38.0 -> 1.38.18 ``                    |
| [`33cd20bb`](https://github.com/NixOS/nixpkgs/commit/33cd20bb9659d92e1cafdbb0941a80ddff143020) | `` python312Packages.mypy-boto3-ecs: 1.38.15 -> 1.38.18 ``                   |
| [`0ec75d14`](https://github.com/NixOS/nixpkgs/commit/0ec75d143135781fb12c89325c45a2f9bdf68ba3) | `` python312Packages.mypy-boto3-dms: 1.38.0 -> 1.38.17 ``                    |
| [`919b3ea4`](https://github.com/NixOS/nixpkgs/commit/919b3ea45ac3bfa2b988422c7de6efa199345cc8) | `` python312Packages.mypy-boto3-controltower: 1.38.15 -> 1.38.17 ``          |
| [`16e7a561`](https://github.com/NixOS/nixpkgs/commit/16e7a56185086866e395daa7e94bc8c5640ff770) | `` python312Packages.mypy-boto3-codepipeline: 1.38.12 -> 1.38.18 ``          |
| [`0089402b`](https://github.com/NixOS/nixpkgs/commit/0089402b324eb4df209efd0c4f4696dc2acf0731) | `` python312Packages.mypy-boto3-codebuild: 1.38.2 -> 1.38.17 ``              |
| [`b3bf51cb`](https://github.com/NixOS/nixpkgs/commit/b3bf51cbb64364560371e44aec8378c8aec5ab52) | `` python312Packages.wheel-inspect: refactor ``                              |
| [`6e7d5974`](https://github.com/NixOS/nixpkgs/commit/6e7d5974b862d6ffa7ebd84e8abdfc1d42f8f7ea) | `` python312Packages.wheel-filename: refactor ``                             |
| [`d961728d`](https://github.com/NixOS/nixpkgs/commit/d961728d54677345725a6351bfa615be90950b36) | `` python313Packages.entry-points-txt: refactor ``                           |
| [`be6f918c`](https://github.com/NixOS/nixpkgs/commit/be6f918c25a2cdccca4f643601e319b7838fd0b2) | `` presenterm: 0.13.0 -> 0.14.0 ``                                           |
| [`57d82741`](https://github.com/NixOS/nixpkgs/commit/57d82741184416b1ebecb2fa9627cb10b308b3cc) | `` workflows/eval: fix process job with author id argument ``                |
| [`c1053a2e`](https://github.com/NixOS/nixpkgs/commit/c1053a2ea8740f3cdbee29f1fedfe3467d267283) | `` tomcat: 11.0.6 -> 11.0.7 ``                                               |
| [`f88761e2`](https://github.com/NixOS/nixpkgs/commit/f88761e23c726abf4fe68c2a316c5d7f465e8af6) | `` tomcat9: 9.0.104 -> 9.0.105 ``                                            |
| [`63611760`](https://github.com/NixOS/nixpkgs/commit/63611760d347c9eb04447d8bc8780ff25771600f) | `` jetty: 12.0.20 -> 12.0.21 ``                                              |
| [`147f9b9a`](https://github.com/NixOS/nixpkgs/commit/147f9b9ad953b4f3464e3f053ebe63f343b42c59) | `` tomcat10: 10.1.40 -> 10.1.41 ``                                           |
| [`45bc5cc3`](https://github.com/NixOS/nixpkgs/commit/45bc5cc3318c1d310aba2c1a8cac0bc3dc896594) | `` python3Packages.python-octaviaclient: 3.10.0 -> 3.11.0 ``                 |
| [`e58d3c0f`](https://github.com/NixOS/nixpkgs/commit/e58d3c0f59fc93035306bdd07dc750efc6e97992) | `` python312Packages.lama-index: update build-system ``                      |
| [`86cfd412`](https://github.com/NixOS/nixpkgs/commit/86cfd4121ceebbb24c97625df4bafbeb876061ff) | `` python312Packages.curated-transformers: 0.1.1 -> 2.0.1 ``                 |
| [`d97b8fd3`](https://github.com/NixOS/nixpkgs/commit/d97b8fd33a7c4b19fcf3eb9b13e624058f247ecc) | `` maintainers: updated ohheyrj ``                                           |
| [`1139e42f`](https://github.com/NixOS/nixpkgs/commit/1139e42f9bf8acd98580d2a90846e2154ae3a684) | `` re-flex: 5.2.2 -> 5.5.0 ``                                                |
| [`3cc678fa`](https://github.com/NixOS/nixpkgs/commit/3cc678fad5bfefaefddf6392acce43e35c7a5363) | `` gnomeExtensions.gsconnect: 58 -> 62 ``                                    |
| [`98c6384a`](https://github.com/NixOS/nixpkgs/commit/98c6384abe2441560bfbc2bd6b274ca0ecac42a2) | `` uncrustify: 0.80.1 -> 0.81.0 ``                                           |
| [`2d72f28a`](https://github.com/NixOS/nixpkgs/commit/2d72f28a381e9c71ecc7aee25ee77ef7b520fd84) | `` python312Packages.llama-index-core: 0.12.23 -> 0.12.35 ``                 |
| [`7d11816d`](https://github.com/NixOS/nixpkgs/commit/7d11816d36e6ed2f4108ab787aaac316fd8b972e) | `` python312Packages.llama-index-agent-openai: 0.4.6 -> 0.4.7 ``             |
| [`4e03a8ac`](https://github.com/NixOS/nixpkgs/commit/4e03a8ac2b907ea502007ed1ab4883ad26287515) | `` python312Packages.llama-index-embeddings-huggingface: 0.5.3 -> 0.5.4 ``   |
| [`f9aa2ca7`](https://github.com/NixOS/nixpkgs/commit/f9aa2ca7fff52f1619ae52cf2e61bb3128cc6e11) | `` python312Packages.llama-index-graph-stores-neptune: 0.3.2 -> 0.3.3 ``     |
| [`7efba6d0`](https://github.com/NixOS/nixpkgs/commit/7efba6d0f69daf0de192626c72627bb002813027) | `` python312Packages.llama-index-llms-openai: 0.3.33 -> 0.3.38 ``            |
| [`f6cadae0`](https://github.com/NixOS/nixpkgs/commit/f6cadae0e1373773d7863067d505e326c9ae64e2) | `` python312Packages.llama-index-vector-stores-postgres: 0.4.2 -> 0.5.3 ``   |
| [`529143f3`](https://github.com/NixOS/nixpkgs/commit/529143f3d77dff5e1545388c791b2232cf602658) | `` ci/nix: 2.24 -> 2.28 ``                                                   |
| [`cf08ae83`](https://github.com/NixOS/nixpkgs/commit/cf08ae834ca6a67b07790781eb3b6506267b1b4c) | `` vimPlugins.yaml-schema-detect-nvim: init at 2025-05-15 ``                 |
| [`d52066e2`](https://github.com/NixOS/nixpkgs/commit/d52066e2b12d0f5470f6b35e7a1961846bde4e5c) | `` ci/eval/compare: manage the "by: package-maintainer" label ``             |
| [`88a11b00`](https://github.com/NixOS/nixpkgs/commit/88a11b003a70cd5c52e5291b7cb14ad92c9eb758) | `` vscodium: 1.100.13210 -> 1.100.23258 ``                                   |
| [`c77b9c58`](https://github.com/NixOS/nixpkgs/commit/c77b9c5842f064adcfb3d5f3163bd9cbf451928d) | `` gnomeExtensions.applications-menu: fix GMenu import ``                    |
| [`f4a07b37`](https://github.com/NixOS/nixpkgs/commit/f4a07b37abcfd215c9a4e5e739a41bd6ae3bd36a) | `` python313Packages.apispec: refactor ``                                    |
| [`ae2ba477`](https://github.com/NixOS/nixpkgs/commit/ae2ba4778a6c6ea8e28753b992fba7898b49c1a7) | `` python313Packages.nomadnet: 0.6.2 -> 0.7.0 ``                             |
| [`e98f25a3`](https://github.com/NixOS/nixpkgs/commit/e98f25a399ad169cf4ed0e79da50cb32ed53d3d8) | `` python313Packages.django-widget-tweaks: refactor ``                       |
| [`336fa33f`](https://github.com/NixOS/nixpkgs/commit/336fa33fcbfcb52b5f0fff9ef2b44784a07d1dcc) | `` vimPlugins.yaml-companion-nvim: init at 2024-07-14 ``                     |
| [`fb9eceb9`](https://github.com/NixOS/nixpkgs/commit/fb9eceb9ac507b03f5625f1cae22f7a43ae4a668) | `` pdi: 1.9.0 -> 1.9.1 ``                                                    |
| [`dc3f7326`](https://github.com/NixOS/nixpkgs/commit/dc3f732627f00be21f39be6c4078ed3211e2abf3) | `` qdrant: 1.13.6 -> 1.14.0 ``                                               |
| [`3662e580`](https://github.com/NixOS/nixpkgs/commit/3662e580ac1542144ed66d06bee56840f58b2e83) | `` f2: enable checks ``                                                      |
| [`a6bc3c12`](https://github.com/NixOS/nixpkgs/commit/a6bc3c12bce7e39abe5128e7e5193ac6153b43e6) | `` wcc: fix source hash ``                                                   |
| [`12993779`](https://github.com/NixOS/nixpkgs/commit/12993779e5d2ac17b52d4ed677a7b20a0108898d) | `` f2: add passthru.updateScript ``                                          |
| [`40e8b3db`](https://github.com/NixOS/nixpkgs/commit/40e8b3db117b31b90073ea2fd513bde3fa33a2c1) | `` f2: add prince213 to maintainers ``                                       |
| [`b572f508`](https://github.com/NixOS/nixpkgs/commit/b572f5085ab9b0fc396da75d52e1c684d10c28c7) | `` tar2ext4: 0.12.8 -> 0.13.0 ``                                             |
| [`dfcb90fc`](https://github.com/NixOS/nixpkgs/commit/dfcb90fcf3cb21c90a0841258e1b2b3a5ff11579) | `` webkitgtk_6_0: 2.48.1 → 2.48.2 ``                                         |
| [`6dd7fe68`](https://github.com/NixOS/nixpkgs/commit/6dd7fe686beb9bd62a92d7e6d13191187e5c825f) | `` prometheus-solaredge-exporter: fix src hash ``                            |
| [`f42172f7`](https://github.com/NixOS/nixpkgs/commit/f42172f73b333658b4c2f02ea7f051c665d59b71) | `` fancy-cat: update hash and mark broken ``                                 |
| [`1fbf90ec`](https://github.com/NixOS/nixpkgs/commit/1fbf90eccece787110aafc11e55c5a3be388055c) | `` hextazy: fix src hash ``                                                  |
| [`d7efac4c`](https://github.com/NixOS/nixpkgs/commit/d7efac4c88d144ce9a5efebcc025c483d7a54cef) | `` python3Packages.sqlmap: 1.9.4 -> 1.9.5 ``                                 |
| [`d35f4a4c`](https://github.com/NixOS/nixpkgs/commit/d35f4a4cbe18b1ea0b8655e30bc29c242f426f2f) | `` teams-for-linux: 2.0.12 -> 2.0.13 ``                                      |
| [`5f9a754f`](https://github.com/NixOS/nixpkgs/commit/5f9a754f2b8b800efcd623210820c0e2522280e1) | `` nhost-cli: 1.29.6 -> 1.29.7 ``                                            |
| [`e8664ee4`](https://github.com/NixOS/nixpkgs/commit/e8664ee4af127c15fae17cfe2c4d72aa4c449b90) | `` gojq: use finalAttrs style ``                                             |
| [`21e92ded`](https://github.com/NixOS/nixpkgs/commit/21e92ded996c8554811058ae6a06bdede3f6dc70) | `` salmon: add missing dependency ``                                         |
| [`94a74b3f`](https://github.com/NixOS/nixpkgs/commit/94a74b3f88ae5e35d472533b5c7f08403408b9ac) | `` mos: 3.4.1 -> 3.5.0 ``                                                    |
| [`e3b9e54d`](https://github.com/NixOS/nixpkgs/commit/e3b9e54d07acac6e72dbcede4e5a5b61d80e7ef7) | `` create-react-app: drop ``                                                 |
| [`5e15dfdd`](https://github.com/NixOS/nixpkgs/commit/5e15dfdd5634150dcb1dbba235dbcd4648515e7e) | `` wayfarer: 1.2.4 -> 1.2.4-unstable-2025-04-12 ``                           |
| [`94e7e3f3`](https://github.com/NixOS/nixpkgs/commit/94e7e3f3506249fc65c83b9c5879799eb685e1aa) | `` nixos/tests/vaultwarden: fix UI testing ``                                |
| [`c97f91a5`](https://github.com/NixOS/nixpkgs/commit/c97f91a5a25b7706c4622438878852cdf92ff767) | `` tilda: fix build ``                                                       |
| [`52583b47`](https://github.com/NixOS/nixpkgs/commit/52583b47d92d5000c67a43183d5a769757003857) | `` gat: 0.23.1 -> 0.23.2 ``                                                  |
| [`a85c0fb5`](https://github.com/NixOS/nixpkgs/commit/a85c0fb50415b7aa1a24ce284bd305d94e473fd4) | `` unicap: drop ``                                                           |
| [`b788cf16`](https://github.com/NixOS/nixpkgs/commit/b788cf1621cd798d52a109adfaee0d061ed91d82) | `` gotify-server: 2.6.1 -> 2.6.3 ``                                          |
| [`73c6a4b9`](https://github.com/NixOS/nixpkgs/commit/73c6a4b92a8a75d6ccd04aaed6921507a8e29d7d) | `` ty: init at 0.0.1-alpha.5 ``                                              |
| [`2418a90d`](https://github.com/NixOS/nixpkgs/commit/2418a90da99bcc44d0bb9fa4db42226b8983066b) | `` tkgate: drop ``                                                           |
| [`6b573473`](https://github.com/NixOS/nixpkgs/commit/6b573473413b9b192fee4640d3935c8326330e91) | `` newlisp: set meta.platforms to lib.platforms.all ``                       |
| [`75097de8`](https://github.com/NixOS/nixpkgs/commit/75097de8fb1ca1068ff076fdcdb45669ff7be7f7) | `` nixos/doc/rl-2505: Fix wording of `users.users` subuid allocation note `` |
| [`57c69d2b`](https://github.com/NixOS/nixpkgs/commit/57c69d2b5b719035ac2a1147f32e9c49d817f47c) | `` luau-lsp: 1.46.0 -> 1.47.0 ``                                             |
| [`9137c96a`](https://github.com/NixOS/nixpkgs/commit/9137c96a533fad989716f7c4e18eb71e919a1d81) | `` xfce.thunar: 4.20.2 -> 4.20.3 ``                                          |
| [`6e89b5e1`](https://github.com/NixOS/nixpkgs/commit/6e89b5e133474308db80a058b38b2eeaa85d4a63) | `` trilium-server: fix build error ``                                        |
| [`15b37c92`](https://github.com/NixOS/nixpkgs/commit/15b37c923be0914b6967340b0d8a12fa3efb5e38) | `` mapmap: drop ``                                                           |
| [`7dc90ab0`](https://github.com/NixOS/nixpkgs/commit/7dc90ab0f48d3874998df20838bf88c284cd42a3) | `` python3Packages.rq: 2.3.2 -> 2.3.3 ``                                     |
| [`8bc90bcf`](https://github.com/NixOS/nixpkgs/commit/8bc90bcf8790b050b89dd63d855b0d5942779a49) | `` cde: drop ``                                                              |
| [`6a200f80`](https://github.com/NixOS/nixpkgs/commit/6a200f806867a8ba77eea6535bdd3ed5815b8698) | `` suitesparse_4_2: drop ``                                                  |
| [`b35a6817`](https://github.com/NixOS/nixpkgs/commit/b35a681762866b073ea4db721884453c6ad2bc6f) | `` suitesparse_4_4: drop ``                                                  |
| [`9266b724`](https://github.com/NixOS/nixpkgs/commit/9266b724243428fe549aa19e934812eb3c14f017) | `` nixosTests.curl-impersonate: skip failing test ``                         |
| [`7947814a`](https://github.com/NixOS/nixpkgs/commit/7947814a841e3340883e68a174967fc3066fff69) | `` snapcraft: make SSL certs available during tests ``                       |
| [`a0d202cd`](https://github.com/NixOS/nixpkgs/commit/a0d202cd8dea01b0bb82fb76cea8b9a6cede2fdc) | `` scummvm: fix aarch64-darwin ranlib path ``                                |
| [`a160a4c3`](https://github.com/NixOS/nixpkgs/commit/a160a4c3f9a34b2858ee68885b32eaba8211c3ad) | `` sgrep: drop ``                                                            |
| [`c3954750`](https://github.com/NixOS/nixpkgs/commit/c3954750dd0975756f6649fcb6477d3990e8f889) | `` evcc: 0.203.5 -> 0.203.6 ``                                               |
| [`2f9867b0`](https://github.com/NixOS/nixpkgs/commit/2f9867b09469d550b410fcffc3694157172024bb) | `` axmldec: drop ``                                                          |
| [`e1e19d75`](https://github.com/NixOS/nixpkgs/commit/e1e19d750e8d1b276ebb818a5b2dd4fb0f288c42) | `` geoclock: init at 1.0.0 ``                                                |
| [`1efa67df`](https://github.com/NixOS/nixpkgs/commit/1efa67dfcc27fcfe51f6fe5b4a78737990182532) | `` maintainers: add fgrcl ``                                                 |